### PR TITLE
Add table of nodes/gateways/last-seen to homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "base64-url": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
@@ -121,6 +127,33 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -128,6 +161,21 @@
       "requires": {
         "hoek": "4.2.1"
       }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "camelcase": {
       "version": "1.2.1",
@@ -275,6 +323,12 @@
           "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
         }
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "connect": {
       "version": "2.30.2",
@@ -554,7 +608,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "cookie-jar": {
       "version": "0.2.0",
@@ -609,7 +663,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.2.1"
           }
@@ -993,7 +1047,7 @@
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "integrity": "sha1-cPt8oCkO5v+WEJBBX0s989IIJlk=",
       "dev": true
     },
     "forwarded": {
@@ -1001,12 +1055,32 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-readlink": {
@@ -1031,7 +1105,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -1042,7 +1116,18 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1052,6 +1137,21 @@
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.14.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1067,7 +1167,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -1142,6 +1242,22 @@
           }
         }
       }
+    },
+    "jasmine": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+      "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "jasmine-core": "3.1.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+      "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1232,7 +1348,7 @@
     "memjs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/memjs/-/memjs-1.1.0.tgz",
-      "integrity": "sha512-Ml+HN3vHl6vpLhAut86l5+tDtpmGhem75KaAWCdN3a3HVFz02bQTM0O3xRhxR9fX2y+CDjna+0UV3MsSspR3Hw=="
+      "integrity": "sha1-fSzS4IM95pfOxdy4srOjLP+6tb8="
     },
     "method-override": {
       "version": "2.3.10",
@@ -1268,14 +1384,23 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "requires": {
         "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1354,6 +1479,15 @@
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -1366,6 +1500,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "pause": {
       "version": "0.1.0",
@@ -1385,7 +1525,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
     "promise": {
@@ -1404,13 +1544,46 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.4.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+        }
+      }
     },
     "readable-stream": {
       "version": "1.1.14",
@@ -1431,7 +1604,7 @@
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -1571,10 +1744,15 @@
         }
       }
     },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "requires": {
         "hoek": "4.2.1"
       }
@@ -1633,7 +1811,7 @@
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -1651,7 +1829,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1666,13 +1844,13 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1687,7 +1865,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1708,7 +1886,7 @@
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -1769,7 +1947,7 @@
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.18"
@@ -1820,7 +1998,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "vary": {
       "version": "1.1.2",
@@ -1999,6 +2177,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "url": "https://github.com/sudomesh/monitor/issues"
   },
   "dependencies": {
-    "express": "~3.21.2",
-    "morgan": "~1.0.0",
+    "body-parser": "^1.18.2",
     "debug": "~0.7.4",
+    "express": "~3.21.2",
     "jade": "~1.11.0",
     "less-middleware": "0.1.15",
-    "winston": "0.7.3",
-    "memjs": "1.1.0"
+    "memjs": "1.1.0",
+    "morgan": "~1.0.0",
+    "winston": "0.7.3"
   },
   "devDependencies": {
     "jasmine": "^3.1.0",

--- a/simulate-activity.js
+++ b/simulate-activity.js
@@ -1,25 +1,81 @@
 var request = require('request');
 var env = require('node-env-file');
+var exitnodeIp = '45.34.140.42';
 
 env(__dirname + '/.env');
 
-var exitnodeIp = '45.34.140.42';
-var options = {
-  url: `http://localhost:${process.env.PORT}/api/v0/monitor`,
-  // the server authenticates the request by looking at
-  // its source ip or x-forwarded-for header
-  headers: {
-    'x-forwarded-for': exitnodeIp,
-    'content-type': 'application/json'
-  },
-  body: '{ "numberOfGateways": 15, "numberOfRoutes": 21 }'
-};
+if (require.main === module) {
+  main()
+    .then(() => {
+      process.exit(0)
+    })
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    })
+}
 
-console.log(`POST ${options.url}`);
-request.post(options, (error, response) => {
-  if (!error && response.statusCode == 200) {
-    console.log('success');
-  } else {
-    console.log(error);
+async function main() {
+  return Promise.all([
+    simulateMonitorRequest({ "numberOfGateways": 15, "numberOfRoutes": 21 }),
+    simulateRoutingTableRequest('127.0.0.0/8,127.0.0.1|128.0.0.0/8,128.0.0.1|129.0.0.0/8,129.0.0.1|')
+  ])
+}
+
+async function simulateMonitorRequest(data) {
+  const response = await monitorRequest(data)
+  switch (response.statusCode) {
+    case 200:
+      console.info(`Successful /monitor request`)
+      break;
+    default:
+      throw new Error("Unexpected statusCode from simulated monitor request: ${response.statusCode}")
   }
-});
+}
+
+async function monitorRequest(data) {
+  return new Promise((resolve, reject) => {
+    var options = {
+      url: `http://localhost:${process.env.PORT}/api/v0/monitor`,
+      // the server authenticates the request by looking at
+      // its source ip or x-forwarded-for header
+      headers: {
+        'x-forwarded-for': exitnodeIp,
+        'content-type': 'application/json'
+      },
+      body: (typeof data === 'object') ? JSON.stringify(data) : data
+    };
+    request.post(options, (error, response) => {
+      if (error) return reject(error)
+      return resolve(response)
+    })
+  })  
+}
+
+async function simulateRoutingTableRequest(body) {
+  const response = await routingTableRequest(body)
+  switch (response.statusCode) {
+    case 200:
+      console.info(`Successful /routing-table request`)
+      break;
+    default:
+      throw new Error("Unexpected statusCode from simulated routing table request: ${response.statusCode}")
+  }
+}
+
+async function routingTableRequest(body) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      url: `http://localhost:${process.env.PORT}/routing-table`,
+      headers: {
+        'x-forwarded-for': exitnodeIp,
+        'content-type': 'text/plain'
+      },
+      body
+    }
+    request.post(options, (error, response) => {
+      if (error) return reject(error)
+      return resolve(response)
+    })
+  })
+}

--- a/util.js
+++ b/util.js
@@ -34,10 +34,10 @@ module.exports.nonZeroOrNA = nonZeroOrNA
  * Computes message for Jade template from data returned from memcache.
  */
 module.exports.messageFromCacheData = function(v) {
+  const d = (typeof v === 'string') ? JSON.parse(v) : v
   //TODO differentiate null v, non-json v, etc.
-  if (v) {
+  if (d) {
     //TODO What happens when parse fails?
-    let d = JSON.parse(v);
     return `Yes! Connecting [${d.numberOfRoutes}] nodes via [${d.numberOfGateways}] gateways.`;
   } else {
     return noCheckInMessage;

--- a/views/index.jade
+++ b/views/index.jade
@@ -8,4 +8,20 @@ block content
   p Please help make this page better at 
     a(href='https://github.com/sudomesh/monitor') https://github.com/sudomesh/monitor
 
+  h3="nodes"  
+  if nodes
+    table.table
+      thead
+        tr
+          th='node'
+          th='gateway'
+          th='last seen'
+      tbody
+        each node in nodes
+          if node.nodeIP && node.gatewayIP && node.timestamp
+            tr
+              td=node.nodeIP
+              td=node.gatewayIP
+              td=node.timestamp
+
   img(src='diagram.jpg')


### PR DESCRIPTION
Resolves #8.

Also
* `simulate-activity.js` - now sends sample data to /routing-table to populate 'nodes' key in memcache, and thus provide the right data to this. Someone should check the sample data I used. I generated it from a PON-connected laptop, but not exit node.

Discovered while implementing:
* Bad data is getting into the db under 'nodes'. Specifically, an entry with timestamp only and no nodeIP or gatewayIP.