### PR TITLE
Fix failing test

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,10 +25,10 @@ app.use(app.router);
 winston.add(winston.transports.File, { filename: logFile });
 
 // Only ips in this list are allowed to POST monitor updates
-const exitnodeIps = ['45.34.140.42'];
+const exitNodeIPs = ['45.34.140.42'];
 const ipAuthMiddleware = (req, res, next) => {
   const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-  if (exitnodeIps.includes(ip)) {
+  if (exitNodeIPs.includes(ip)) {
     console.log('Received update from exit node ' + ip);
     next();
   } else {
@@ -167,5 +167,6 @@ app.use(function(err, req, res, next) {
   });
 });
 
+app.exitNodeIPs = exitNodeIPs;
 module.exports = app;
 

--- a/spec/httpSpec.js
+++ b/spec/httpSpec.js
@@ -33,7 +33,7 @@ describe('POST /api/v0/monitor', function () {
   it('error on malformed exit node', function (done) {
     supertest(application)
         .post('/api/v0/monitor')
-        .set('x-forwarded-for', application.exitnodes[0])
+        .set('x-forwarded-for', application.exitNodeIPs[0])
         .accept('Content-Type', 'application/json')
         .expect({ error: 'Bad request' })
         .expect(400, done);


### PR DESCRIPTION
- Make sure same name (`exitNodeIPs`) used in `app.js` and
`spec/httpSpec.js`
- Consistent case
- Add `exitNodeIPs` to `app` before export in order to make it available
to `httpSpec.js`