### PR TITLE
MonitorApp error middleware uses 500 status code

### DIFF
--- a/app.js
+++ b/app.js
@@ -133,26 +133,12 @@ function MonitorApp ({
   });
 
   /// Error Handlers
-
-  // development error handler
-  // will print stacktrace
-  if (app.get('env') === 'development') {
-      app.use(function(err, req, res, next) {
-          res.render('error', {
-              message: err.message,
-              error: err
-          });
-      });
-  }
-
-  // production error handler
-  // no stacktraces leaked to user
-  app.use(function(err, req, res, next) {
-    res.render('error', {
+  app.use((err, req, res, next) => {
+    res.status(500).render('error', {
       message: err.message,
-      error: {}
-    });
-  });
+      error: (app.get('env') === 'development') ? err : {} // only render full error in development env
+    })
+  })
 
   app.exitNodeIPs = exitNodeIPs;
   return app


### PR DESCRIPTION
This will help the home page test fail when errors are introduced like my last commit fixed.